### PR TITLE
Fix parse template error

### DIFF
--- a/lib/docx_synthesizer/template.rb
+++ b/lib/docx_synthesizer/template.rb
@@ -21,7 +21,7 @@ module DocxSynthesizer
 
       begin
         stream.each do |entry|
-          zip_contents[entry.name] = entry.get_input_stream.read
+          zip_contents[entry.name] = entry.get_input_stream.try(:read)
         end
       rescue
         raise InvalidTemplateError

--- a/lib/docx_synthesizer/version.rb
+++ b/lib/docx_synthesizer/version.rb
@@ -1,3 +1,3 @@
 module DocxSynthesizer
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end


### PR DESCRIPTION
修复 WPS 保存过的 docx 文档无法解析。
因为他读取文件的时候 会返回 Zip::NullInputStream，这里直接调read 方法会报错，导致无法打印